### PR TITLE
[IMP] mail: control file type to upload

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -15,7 +15,7 @@ from odoo.tools.misc import get_lang
 from odoo.tools.translate import _
 from werkzeug.exceptions import NotFound
 
-DEFAULT_BLACKLIST_FILE_TYPE = ['text/html']
+DEFAULT_BLACKLIST_FILE_TYPE = ['text/html', 'text/javascript']
 
 
 class DiscussController(http.Controller):

--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -15,6 +15,8 @@ from odoo.tools.misc import get_lang
 from odoo.tools.translate import _
 from werkzeug.exceptions import NotFound
 
+DEFAULT_BLACKLIST_FILE_TYPE = ['text/html']
+
 
 class DiscussController(http.Controller):
 
@@ -237,6 +239,20 @@ class DiscussController(http.Controller):
 
     @http.route('/mail/attachment/upload', methods=['POST'], type='http', auth='public')
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
+        # BEGIN OVERIDE
+        blacklist_file_types = request.env['ir.config_parameter'].sudo().get_param(
+            'mail.blacklist_file_types',
+            default=DEFAULT_BLACKLIST_FILE_TYPE)
+        if isinstance(blacklist_file_types, str):
+            blacklist_file_types = blacklist_file_types.split(',')
+        # TODO: create a module if making pr for odoo not working
+        if any(blacklist_type in ufile.mimetype for blacklist_type in blacklist_file_types):
+            attachmentData = {'error': _("You are not allowed to upload attachment with extension %s here.", ufile.mimetype)}
+            return request.make_response(
+                data=json.dumps(attachmentData),
+                headers=[('Content-Type', 'application/json')]
+            )
+        # END OVERIDE
         channel_partner = request.env['mail.channel.partner']
         if thread_model == 'mail.channel':
             channel_partner = request.env['mail.channel.partner']._get_as_sudo_from_request_or_raise(request=request, channel_id=int(thread_id))

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -7558,6 +7558,12 @@ msgid "You are not allowed to upload an attachment here."
 msgstr ""
 
 #. module: mail
+#: code:addons/mail/controllers/discuss.py:0
+#, python-format
+msgid "You are not allowed to upload attachment with extension %s here."
+msgstr ""
+
+#. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js:0
 #, python-format

--- a/addons/mail/i18n/vi.po
+++ b/addons/mail/i18n/vi.po
@@ -7888,6 +7888,12 @@ msgid "You are not allowed to upload an attachment here."
 msgstr "Bạn không có quyền tải lên file đính kèm ở đây."
 
 #. module: mail
+#: code:addons/mail/controllers/discuss.py:0
+#, python-format
+msgid "You are not allowed to upload attachment with extension %s here."
+msgstr "Bạn không có quyền tải lên file đính kèm có đuôi mở rộng loại %s ở đây."
+
+#. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js:0
 #, python-format


### PR DESCRIPTION
-Before this commit: user can upload any file type they want, problem is someone might upload virus file like html one which contain toxic code 
-After this commit: provide a way to config which file types is blacklist (can't be uploaded) by using system parameter call "mail.blacklist_file_types"

Description of the issue/feature this PR addresses: https://viindoo.com/web#id=92023&cids=1&menu_id=89&model=project.task&view_type=form


https://github.com/Viindoo/customer-s5t-odoo/assets/56789189/cad7f52e-ea91-4318-8dbc-093d66f1fad6






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
