### PR TITLE
[IMP] core: secure cookie for session_id

### DIFF
--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -54,7 +54,7 @@ class TestBlogPerformance(UtilPerf):
             blog_tags = blog_tags[:-1]
         self.assertEqual(self._get_url_hot_query('/blog'), 26)
         self.assertEqual(self._get_url_hot_query('/blog', cache=False), 25)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 29)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 30)
         self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 28)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -55,7 +55,7 @@ class TestBlogPerformance(UtilPerf):
         self.assertEqual(self._get_url_hot_query('/blog'), 26)
         self.assertEqual(self._get_url_hot_query('/blog', cache=False), 25)
         self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 30)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 28)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 29)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1466,8 +1466,11 @@ class Root(object):
         #   (the one using the cookie). That is a special feature of the Session Javascript class.
         # - It could allow session fixation attacks.
         if not explicit_session and hasattr(response, 'set_cookie'):
+            # BEGIN OVERIDE
+            # TODO: add secure=True for odoo v15
             response.set_cookie(
-                'session_id', httprequest.session.sid, max_age=90 * 24 * 60 * 60, httponly=True)
+                'session_id', httprequest.session.sid, max_age=90 * 24 * 60 * 60, secure=True, httponly=True)
+            # END OVERIDE
 
         return response
 


### PR DESCRIPTION
-The Secure attribute for sensitive cookies in an HTTPS session is not set, which could cause users to send those cookies in plaintext over an insecure encrypted transmission (HTTP).

Description of the issue/feature this PR addresses: https://viindoo.com/web#id=92024&cids=1&menu_id=89&model=project.task&view_type=form

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
