### PR TITLE
[IMP] http: remove server headers out of response

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -126,6 +126,11 @@ class RequestHandler(werkzeug.serving.WSGIRequestHandler):
         me = threading.current_thread()
         me.name = 'odoo.service.http.request.%s' % (me.ident,)
 
+    def send_header(self, keyword, value):
+        if keyword == 'Server':
+            return
+        return super(RequestHandler, self).send_header(keyword, value)
+
 
 class ThreadedWSGIServerReloadable(LoggingBaseWSGIServerMixIn, werkzeug.serving.ThreadedWSGIServer):
     """ werkzeug Threaded WSGI Server patched to allow reusing a listen socket


### PR DESCRIPTION
-Before this commit when perform any request to server the headers always include 'Server'
-After this commit it not there any more just empty

Description of the issue/feature this PR addresses: https://viindoo.com/web#id=92032&cids=1&model=project.task&view_type=form

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
