### PR TITLE
[MISC] http_routing: disable traceback for debugging

### DIFF
--- a/addons/http_routing/views/http_routing_template.xml
+++ b/addons/http_routing/views/http_routing_template.xml
@@ -49,7 +49,7 @@
                     </div>
                 </div>
             </div>
-            <div class="card" t-if="traceback">
+            <!--<div class="card" t-if="traceback">
                 <h4 class="card-header">
                     <a data-toggle="collapse" href="#error_traceback">Traceback</a>
                 </h4>
@@ -58,7 +58,7 @@
                         <pre id="exception_traceback" t-esc="traceback"/>
                     </div>
                 </div>
-            </div>
+            </div>-->
         </div>
     </template>
 


### PR DESCRIPTION
-Before this commit: if user enable debug (both internal and portal) then he/she can view almost full stacktrace of the error -After this commit: no one can do that any more, it only display the error only

Task: https://viindoo.com/web#id=92030&cids=1&model=project.task&view_type=form




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
