### PR TITLE
[IMP] core: html field content should be validate

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1836,6 +1836,8 @@ class Html(_String):
     def convert_to_cache(self, value, record, validate=True):
         if value is None or value is False:
             return None
+        if validate and value and isinstance(value, str) and not value.startswith("<p"):
+            value = value.replace("<", "&lt;").replace("/>", "/&gt;")
         if validate and self.sanitize:
             return html_sanitize(
                 value, silent=True,


### PR DESCRIPTION
-Before this commit: when user try to call write (using rpc or call in the code not in the interface) and pass value for html field like "<img src='x'/>" then it will display as a broken image
-After this commit, special html tag will be replaced accordingly

Task: https://viindoo.com/web#id=92034&cids=1&model=project.task&view_type=form

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
