### PR TITLE
[IMP] bus, web_editor: prevent invalid session_id

### DIFF
--- a/addons/bus/controllers/main.py
+++ b/addons/bus/controllers/main.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import os
 
-from odoo import exceptions, _
+from odoo import exceptions, _, http
 from odoo.http import Controller, request, route
 from odoo.addons.bus.models.bus import dispatch
 
@@ -22,6 +23,13 @@ class BusController(Controller):
 
     @route('/longpolling/poll', type="json", auth="public", cors="*")
     def poll(self, channels, last, options=None):
+        sid = request.httprequest.cookies.get('session_id')
+        if not sid:
+            raise Exception("No session id found")
+        if not http.root.session_store.is_valid_key(sid):
+            raise Exception("Invalid session id: ", sid)
+        if not os.path.isfile(http.root.session_store.get_session_filename(sid)):
+            raise Exception("No session id found")
         if options is None:
             options = {}
         if not dispatch:

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import os
 import io
 import json
 import logging
@@ -513,6 +514,13 @@ class Web_Editor(http.Controller):
     def public_render_template(self, args):
         # args[0]: xml id of the template to render
         # args[1]: optional dict of rendering values, only trusted keys are supported
+        sid = request.httprequest.cookies.get('session_id')
+        if not sid:
+            raise Exception("No session id found")
+        if not http.root.session_store.is_valid_key(sid):
+            raise Exception("Invalid session id: ", sid)
+        if not os.path.isfile(http.root.session_store.get_session_filename(sid)):
+            raise Exception("No session id found")
         len_args = len(args)
         assert len_args >= 1 and len_args <= 2, 'Need a xmlID and potential rendering values to render a template'
 


### PR DESCRIPTION
Task: https://viindoo.com/web#id=92031&cids=1&menu_id=97&model=project.task&view_type=form

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
