### PR TITLE
[IMP] http: remove debug stacktrace in response

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -668,8 +668,10 @@ class JsonRequest(WebRequest):
             error = {
                 'code': 200,
                 'message': "Odoo Server Error",
-                'data': serialize_exception(exception),
+                'data': exception.args and (exception.args[0] or ''),
             }
+            if getattr(threading.current_thread(), 'testing', False):
+                error['data'] = serialize_exception(exception)
             if isinstance(exception, werkzeug.exceptions.NotFound):
                 error['http_status'] = 404
                 error['code'] = 404


### PR DESCRIPTION
-Before this commit, when using json rpc to call route /web_editor/public_render_template with args debug true/false then we will get response containing stacetrack error
-After this commit just display the real error is, for the stacetrack keep it in log file

Task: https://viindoo.com/web#id=92026&cids=1&model=project.task&view_type=form

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
