### PR TITLE
[IMP] http: Response Discrepancy Information Exposure

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -641,9 +641,13 @@ class JsonRequest(WebRequest):
             response['error'] = error
         if result is not None:
             if isinstance(result, list):
+                has_password = False
                 for res in result:
                     if 'password' in res:
                         res["password"] = "*****"
+                        has_password = True
+                if has_password:
+                    result.pop("password")
             response['result'] = result
 
         mime = 'application/json'

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -640,6 +640,10 @@ class JsonRequest(WebRequest):
         if error is not None:
             response['error'] = error
         if result is not None:
+            if isinstance(result, list):
+                for res in result:
+                    if 'password' in res:
+                        res["password"] = "*****"
             response['result'] = result
 
         mime = 'application/json'


### PR DESCRIPTION
-This commit make password in json response return *** instead of empty string ""

Task: https://viindoo.com/web#id=92025&cids=1&menu_id=89&model=project.task&view_type=form

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
